### PR TITLE
feat: add dns resources

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tflint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache plugin dir
+        uses: actions/cache@v3
+        with:
+          path: ~/.tflint.d/plugins
+          key: tflint-${{ hashFiles('.tflint.hcl') }}
+
+      - name: Setup TFLint
+        uses: terraform-linters/setup-tflint@v2
+
+      - name: Init TFLint
+        run: tflint --init
+
+      - name: Run TFLint
+        run: tflint -f compact
+
+  tfsec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: aquasecurity/tfsec-action@v1.0.2

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,5 @@
+plugin "google" {
+  enabled = true
+  version = "0.19.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-google"
+}

--- a/dns.tf
+++ b/dns.tf
@@ -1,0 +1,35 @@
+data "google_dns_managed_zone" "korosuke613_dev" {
+  name = "korosuke613-dev"
+}
+
+resource "google_dns_record_set" "korosuke613_dev_a" {
+  name = data.google_dns_managed_zone.korosuke613_dev.dns_name
+  type = "A"
+  ttl  = 300
+
+  managed_zone = data.google_dns_managed_zone.korosuke613_dev.name
+
+  # https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain
+  rrdatas = [
+    "185.199.108.153",
+    "185.199.109.153",
+    "185.199.110.153",
+    "185.199.111.153"
+  ]
+}
+
+resource "google_dns_record_set" "korosuke613_dev_aaaa" {
+  name = data.google_dns_managed_zone.korosuke613_dev.dns_name
+  type = "AAAA"
+  ttl  = 300
+
+  managed_zone = data.google_dns_managed_zone.korosuke613_dev.name
+
+  # https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain
+  rrdatas = [
+    "2606:50c0:8000::153",
+    "2606:50c0:8001::153",
+    "2606:50c0:8002::153",
+    "2606:50c0:8003::153"
+  ]
+}


### PR DESCRIPTION
```hcl
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # google_dns_record_set.korosuke613_dev_a will be created
  + resource "google_dns_record_set" "korosuke613_dev_a" {
      + id           = (known after apply)
      + managed_zone = "korosuke613-dev"
      + name         = "korosuke613.dev."
      + project      = (known after apply)
      + rrdatas      = [
          + "185.199.108.153",
          + "185.199.109.153",
          + "185.199.110.153",
          + "185.199.111.153",
        ]
      + ttl          = 300
      + type         = "A"
    }

  # google_dns_record_set.korosuke613_dev_aaaa will be created
  + resource "google_dns_record_set" "korosuke613_dev_aaaa" {
      + id           = (known after apply)
      + managed_zone = "korosuke613-dev"
      + name         = "korosuke613.dev."
      + project      = (known after apply)
      + rrdatas      = [
          + "2606:50c0:8000::153",
          + "2606:50c0:8001::153",
          + "2606:50c0:8002::153",
          + "2606:50c0:8003::153",
        ]
      + ttl          = 300
      + type         = "AAAA"
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```