### PR TITLE
fix: add CNAME record

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -33,3 +33,15 @@ resource "google_dns_record_set" "korosuke613_dev_aaaa" {
     "2606:50c0:8003::153"
   ]
 }
+
+resource "google_dns_record_set" "korosuke613_dev_cname" {
+  name = data.google_dns_managed_zone.korosuke613_dev.dns_name
+  type = "CNAME"
+  ttl  = 300
+
+  managed_zone = data.google_dns_managed_zone.korosuke613_dev.name
+
+  rrdatas = [
+    "korosuke613.github.io."
+  ]
+}


### PR DESCRIPTION
```hcl
Terraform used the selected providers to generate the following execution plan.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # google_dns_record_set.korosuke613_dev_cname will be created
  + resource "google_dns_record_set" "korosuke613_dev_cname" {
      + id           = (known after apply)
      + managed_zone = "korosuke613-dev"
      + name         = "korosuke613.dev."
      + project      = (known after apply)
      + rrdatas      = [
          + "korosuke613.github.io.",
        ]
      + ttl          = 300
      + type         = "CNAME"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```