### PR TITLE
fix: subdomain CNAME record

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -34,8 +34,8 @@ resource "google_dns_record_set" "korosuke613_dev_aaaa" {
   ]
 }
 
-resource "google_dns_record_set" "korosuke613_dev_cname" {
-  name = data.google_dns_managed_zone.korosuke613_dev.dns_name
+resource "google_dns_record_set" "www_korosuke613_dev_cname" {
+  name = "www.${data.google_dns_managed_zone.korosuke613_dev.dns_name}"
   type = "CNAME"
   ttl  = 300
 


### PR DESCRIPTION
```hcl
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # google_dns_record_set.www_korosuke613_dev_cname will be created
  + resource "google_dns_record_set" "www_korosuke613_dev_cname" {
      + id           = (known after apply)
      + managed_zone = "korosuke613-dev"
      + name         = "www.korosuke613.dev."
      + project      = (known after apply)
      + rrdatas      = [
          + "korosuke613.github.io.",
        ]
      + ttl          = 300
      + type         = "CNAME"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```