### PR TITLE
fix: ttl to 86400s

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -5,7 +5,7 @@ data "google_dns_managed_zone" "korosuke613_dev" {
 resource "google_dns_record_set" "korosuke613_dev_a" {
   name = data.google_dns_managed_zone.korosuke613_dev.dns_name
   type = "A"
-  ttl  = 300
+  ttl  = 86400
 
   managed_zone = data.google_dns_managed_zone.korosuke613_dev.name
 
@@ -21,7 +21,7 @@ resource "google_dns_record_set" "korosuke613_dev_a" {
 resource "google_dns_record_set" "korosuke613_dev_aaaa" {
   name = data.google_dns_managed_zone.korosuke613_dev.dns_name
   type = "AAAA"
-  ttl  = 300
+  ttl  = 86400
 
   managed_zone = data.google_dns_managed_zone.korosuke613_dev.name
 
@@ -37,7 +37,7 @@ resource "google_dns_record_set" "korosuke613_dev_aaaa" {
 resource "google_dns_record_set" "www_korosuke613_dev_cname" {
   name = "www.${data.google_dns_managed_zone.korosuke613_dev.dns_name}"
   type = "CNAME"
-  ttl  = 300
+  ttl  = 86400
 
   managed_zone = data.google_dns_managed_zone.korosuke613_dev.name
 


### PR DESCRIPTION
```hcl
Terraform used the selected providers to generate the following execution plan.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # google_dns_record_set.korosuke613_dev_a will be updated in-place
  ~ resource "google_dns_record_set" "korosuke613_dev_a" {
        id           = "projects/korosuke613/managedZones/korosuke613-dev/rrsets/korosuke613.dev./A"
        name         = "korosuke613.dev."
      ~ ttl          = 300 -> 86400
        # (4 unchanged attributes hidden)
    }

  # google_dns_record_set.korosuke613_dev_aaaa will be updated in-place
  ~ resource "google_dns_record_set" "korosuke613_dev_aaaa" {
        id           = "projects/korosuke613/managedZones/korosuke613-dev/rrsets/korosuke613.dev./AAAA"
        name         = "korosuke613.dev."
      ~ ttl          = 300 -> 86400
        # (4 unchanged attributes hidden)
    }

  # google_dns_record_set.www_korosuke613_dev_cname will be updated in-place
  ~ resource "google_dns_record_set" "www_korosuke613_dev_cname" {
        id           = "projects/korosuke613/managedZones/korosuke613-dev/rrsets/www.korosuke613.dev./CNAME"
        name         = "www.korosuke613.dev."
      ~ ttl          = 300 -> 86400
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 3 to change, 0 to destroy.
```