### PR TITLE
feat: add TXT record for github pages

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -45,3 +45,15 @@ resource "google_dns_record_set" "www_korosuke613_dev_cname" {
     "korosuke613.github.io."
   ]
 }
+
+resource "google_dns_record_set" "_github_pages_challenge_korosuke613_korosuke613_dev_txt" {
+  name = "_github-pages-challenge-korosuke613.${data.google_dns_managed_zone.korosuke613_dev.dns_name}"
+  type = "TXT"
+  ttl  = 300
+
+  managed_zone = data.google_dns_managed_zone.korosuke613_dev.name
+
+  rrdatas = [
+    "fcb70d03c1a01a4d5436ef3403a617"
+  ]
+}


### PR DESCRIPTION
```hcl
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # google_dns_record_set._github_pages_challenge_korosuke613_korosuke613_dev_txt will be created
  + resource "google_dns_record_set" "_github_pages_challenge_korosuke613_korosuke613_dev_txt" {
      + id           = (known after apply)
      + managed_zone = "korosuke613-dev"
      + name         = "_github-pages-challenge-korosuke613.korosuke613.dev."
      + project      = (known after apply)
      + rrdatas      = [
          + "fcb70d03c1a01a4d5436ef3403a617",
        ]
      + ttl          = 300
      + type         = "TXT"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```